### PR TITLE
Add category to connector meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 # rspec failure tracking
 .rspec_status
 /.byebug_history
+spec/.DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    multiwoven-integrations (0.1.3)
+    multiwoven-integrations (0.1.4)
       activesupport
       dry-schema
       dry-struct

--- a/lib/multiwoven/integrations/destination/facebook_custom_audience/config/meta.json
+++ b/lib/multiwoven/integrations/destination/facebook_custom_audience/config/meta.json
@@ -3,7 +3,7 @@
     {
       "name": "Facebook",
       "connector_type": "destination",
-      "connector_subtype": "API",
+      "category": "Adtech",
       "documentation_url": "https://docs.mutliwoven.com",
       "github_issue_label": "destination-facebook",
       "icon": "facebook.svg",

--- a/lib/multiwoven/integrations/destination/klaviyo/config/meta.json
+++ b/lib/multiwoven/integrations/destination/klaviyo/config/meta.json
@@ -3,7 +3,7 @@
     {
       "name": "Klaviyo",
       "connector_type": "destination",
-      "connector_subtype": "API",
+      "category": "Marketing Automation",
       "documentation_url": "https://docs.mutliwoven.com",
       "github_issue_label": "destination-klaviyo",
       "icon": "klaviyo.svg",

--- a/lib/multiwoven/integrations/destination/salesforce_crm/config/meta.json
+++ b/lib/multiwoven/integrations/destination/salesforce_crm/config/meta.json
@@ -3,7 +3,7 @@
     {
       "name": "Salesforce CRM",
       "connector_type": "destination",
-      "connector_subtype": "API",
+      "category": "CRM",
       "documentation_url": "https://docs.mutliwoven.com",
       "github_issue_label": "destination-salesforce-crm",
       "icon": "salesforce.svg",

--- a/lib/multiwoven/integrations/destination/slack/config/meta.json
+++ b/lib/multiwoven/integrations/destination/slack/config/meta.json
@@ -2,7 +2,7 @@
   "data": {
     "name": "Slack",
     "connector_type": "destination",
-    "connector_subtype": "API",
+    "category": "Team Collaboration",
     "documentation_url": "https://docs.mutliwoven.com",
     "github_issue_label": "destination-slack",
     "icon": "slack.svg",

--- a/lib/multiwoven/integrations/rollout.rb
+++ b/lib/multiwoven/integrations/rollout.rb
@@ -2,7 +2,7 @@
 
 module Multiwoven
   module Integrations
-    VERSION = "0.1.3"
+    VERSION = "0.1.4"
 
     ENABLED_SOURCES = %w[
       Snowflake

--- a/lib/multiwoven/integrations/source/bigquery/config/meta.json
+++ b/lib/multiwoven/integrations/source/bigquery/config/meta.json
@@ -3,7 +3,7 @@
     {
       "name": "BigQuery",
       "connector_type": "source",
-      "connector_subtype": "database",
+      "category": "Data Warehouse",
       "documentation_url": "https://docs.mutliwoven.com",
       "github_issue_label": "source-bigquery",
       "icon": "bigquery.svg",

--- a/lib/multiwoven/integrations/source/redshift/config/meta.json
+++ b/lib/multiwoven/integrations/source/redshift/config/meta.json
@@ -3,7 +3,7 @@
     {
       "name": "Redshift",
       "connector_type": "source",
-      "connector_subtype": "database",
+      "category": "Data Warehouse",
       "documentation_url": "https://docs.mutliwoven.com",
       "github_issue_label": "source-redshift",
       "icon": "redshift.svg",

--- a/lib/multiwoven/integrations/source/snowflake/config/meta.json
+++ b/lib/multiwoven/integrations/source/snowflake/config/meta.json
@@ -3,7 +3,7 @@
     {
       "name": "Snowflake",
       "connector_type": "source",
-      "connector_subtype": "database",
+      "category": "Data Warehouse",
       "documentation_url": "https://docs.mutliwoven.com",
       "github_issue_label": "source-snowflake",
       "icon": "snowflake.svg",


### PR DESCRIPTION


## Description
Connectors needs to be listed in the UI based on a category field eg: CRM, AdTech. Added category field to meta.json to every connector

## Related Issue
#31 

## Type of Change
- [ ] New Connector (Destination or Source Connector)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Documentation update
- [ ] Chore
  
## How Has This Been Tested?
This is tested via rspec as this is a  minor change.

## Checklist:
- [ ] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [ ] Added the new connector in rollout.rb
- [X] Have you updated the version number of the gem?
- [ ] Have you ensured that your changes for new connector are documented in the [docs repo](https://github.com/Multiwoven/docs) or relevant documentation files?
