### PR TITLE
[Fix] sync data structure issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    multiwoven-integrations (0.1.17)
+    multiwoven-integrations (0.1.18)
       activesupport
       async-websocket
       dry-schema

--- a/lib/multiwoven/integrations/core/base_connector.rb
+++ b/lib/multiwoven/integrations/core/base_connector.rb
@@ -10,6 +10,7 @@ module Multiwoven
       def connector_spec
         @connector_spec ||= begin
           spec_json = keys_to_symbols(read_json(CONNECTOR_SPEC_PATH)).to_json
+          # returns Protocol::ConnectorSpecification
           ConnectorSpecification.from_json(spec_json)
         end
       end
@@ -19,17 +20,20 @@ module Multiwoven
         icon_name = client_meta_data[:data][:icon]
         icon_url = "https://raw.githubusercontent.com/Multiwoven/multiwoven-integrations/#{MAIN_BRANCH_SHA}/assets/images/connectors/#{icon_name}"
         client_meta_data[:data][:icon] = icon_url
-
+        # returns hash
         @meta_data ||= client_meta_data
       end
 
+      # Connection config is a hash
       def check_connection(_connection_config)
         raise "Not implemented"
         # returns Protocol.ConnectionStatus
       end
 
+      # Connection config is a hash
       def discover(_connection_config)
         raise "Not implemented"
+        # returns Protocol::Catalog
       end
 
       private

--- a/lib/multiwoven/integrations/core/destination_connector.rb
+++ b/lib/multiwoven/integrations/core/destination_connector.rb
@@ -3,9 +3,11 @@
 module Multiwoven
   module Integrations::Core
     class DestinationConnector < BaseConnector
+      # records is transformed json payload send it to the destination
+      # SyncConfig is the Protocol::SyncConfig object
       def write(_sync_config, _records, _action = "insert")
         raise "Not implemented"
-        # return list of record message
+        # return Protocol::TrackingMessage
       end
     end
   end

--- a/lib/multiwoven/integrations/core/source_connector.rb
+++ b/lib/multiwoven/integrations/core/source_connector.rb
@@ -3,10 +3,12 @@
 module Multiwoven
   module Integrations::Core
     class SourceConnector < BaseConnector
+      # accepts Protocol::SyncConfig
       def read(_sync_config)
         raise "Not implemented"
         # setup sync configs
         # call query(connection, query)
+        # Returns list of RecordMessage
       end
 
       private

--- a/lib/multiwoven/integrations/core/utils.rb
+++ b/lib/multiwoven/integrations/core/utils.rb
@@ -65,7 +65,7 @@ module Multiwoven
       end
 
       def extract_data(record_object, properties)
-        data_attributes = record_object.with_indifferent_access[:data][:attributes]
+        data_attributes = record_object.with_indifferent_access
         data_attributes.select { |key, _| properties.key?(key.to_sym) }
       end
 

--- a/lib/multiwoven/integrations/destination/facebook_custom_audience/client.rb
+++ b/lib/multiwoven/integrations/destination/facebook_custom_audience/client.rb
@@ -55,7 +55,7 @@ module Multiwoven::Integrations::Destination
         write_success = 0
         write_failure = 0
         records.each do |record|
-          payload = create_payload(record.with_indifferent_access[:data][:attributes], sync_config.stream.json_schema.with_indifferent_access)
+          payload = create_payload(record.with_indifferent_access, sync_config.stream.json_schema.with_indifferent_access)
           response = Multiwoven::Integrations::Core::HttpClient.request(
             url,
             sync_config.stream.request_method,

--- a/lib/multiwoven/integrations/destination/slack/client.rb
+++ b/lib/multiwoven/integrations/destination/slack/client.rb
@@ -72,7 +72,7 @@ module Multiwoven
           def build_args(stream_name, record)
             case stream_name
             when "chat_postMessage"
-              { channel: channel_id, text: slack_code_block(record[:data][:attributes]) }
+              { channel: channel_id, text: slack_code_block(record) }
             else
               raise "Stream name not found: #{stream_name}"
             end

--- a/lib/multiwoven/integrations/destination/slack/config/catalog.json
+++ b/lib/multiwoven/integrations/destination/slack/config/catalog.json
@@ -9,63 +9,12 @@
         "properties": {
           "text": {
             "type": ["string", "null"]
-          },
-          "attachments": {
-            "type": ["string", "null"]
-          },
-          "blocks": {
-            "type": ["array", "null"],
-            "items": {
-              "type": "string"
-            }
-          },
-          "as_user": {
-            "type": ["boolean", "null"]
-          },
-          "icon_emoji": {
-            "type": ["string", "null"]
-          },
-          "icon_url": {
-            "type": ["string", "null"]
-          },
-          "link_names": {
-            "type": ["boolean", "null"]
-          },
-          "metadata": {
-            "type": ["string", "null"]
-          },
-          "mrkdwn": {
-            "type": ["boolean", "null"]
-          },
-          "parse": {
-            "type": ["string", "null"]
-          },
-          "reply_broadcast": {
-            "type": ["boolean", "null"]
-          },
-          "thread_ts": {
-            "type": ["string", "null"]
-          },
-          "unfurl_links": {
-            "type": ["boolean", "null"]
-          },
-          "unfurl_media": {
-            "type": ["boolean", "null"]
-          },
-          "username": {
-            "type": ["string", "null"]
           }
         },
-        "oneOf": [
-          { "required": ["text"] },
-          { "required": ["attachments"] },
-          { "required": ["blocks"] }
-        ]
+        "oneOf": [{ "required": ["text"] }]
       },
       "supported_sync_modes": ["full_refresh", "incremental"],
-      "source_defined_cursor": true,
-      "default_cursor_field": ["updated"],
-      "source_defined_primary_key": [["Id"]]
+      "source_defined_cursor": true
     }
   ]
 }

--- a/lib/multiwoven/integrations/rollout.rb
+++ b/lib/multiwoven/integrations/rollout.rb
@@ -2,7 +2,7 @@
 
 module Multiwoven
   module Integrations
-    VERSION = "0.1.17"
+    VERSION = "0.1.18"
 
     ENABLED_SOURCES = %w[
       Snowflake

--- a/spec/multiwoven/integrations/destination/facebook_custom_audience/client_spec.rb
+++ b/spec/multiwoven/integrations/destination/facebook_custom_audience/client_spec.rb
@@ -121,9 +121,6 @@ RSpec.describe Multiwoven::Integrations::Destination::FacebookCustomAudience::Cl
   end
 
   def build_record(email, country)
-    {
-      "data": { "attributes": { "EMAIL": email, "COUNTRY": country } },
-      "emitted_at": Time.now.to_i
-    }
+    { "EMAIL": email, "COUNTRY": country }
   end
 end

--- a/spec/multiwoven/integrations/destination/salesforce_crm/client_spec.rb
+++ b/spec/multiwoven/integrations/destination/salesforce_crm/client_spec.rb
@@ -129,10 +129,7 @@ RSpec.describe Multiwoven::Integrations::Destination::SalesforceCrm::Client do #
   private
 
   def build_record(id, name)
-    {
-      "data": { "attributes": { "Id": id, "Name": name, NonListedField: "NonListedField Value" } },
-      "emitted_at": Time.now.to_i
-    }
+    { "Id": id, "Name": name, NonListedField: "NonListedField Value" }
   end
 
   def stub_create_request(id, name, response_code)

--- a/spec/multiwoven/integrations/destination/slack/client_spec.rb
+++ b/spec/multiwoven/integrations/destination/slack/client_spec.rb
@@ -127,9 +127,6 @@ RSpec.describe Multiwoven::Integrations::Destination::Slack::Client do
   private
 
   def build_record(id, name)
-    {
-      "data": { "attributes": { "Id": id, "Name": name } },
-      "emitted_at": Time.now.to_i
-    }
+    { "Id": id, "Name": name }
   end
 end


### PR DESCRIPTION
## Description
[Fix] sync data structure issue for destination connectors like slack, facebook and salesforce CRM which was parsing data as data.attribute.destination_field

## Related Issue
None

## Type of Change
- [ ] New Connector (Destination or Source Connector)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Documentation update
- [ ] Chore
  
## How Has This Been Tested?
Tested the slack and salesforce via server API call and updated unit test

## Checklist:
- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [x] Added the new connector in rollout.rb
- [x] Have you updated the version number of the gem?
- [ ] Have you ensured that your changes for new connector are documented in the [docs repo](https://github.com/Multiwoven/docs) or relevant documentation files?
- [ ] Have you updated the run time dependency in multiwoven-integrations.gemspec if new gems are added
