### PR TITLE
fix: Avoid numbers in path created by gem in server

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    multiwoven-integrations (0.1.27)
+    multiwoven-integrations (0.1.28)
       activesupport
       async-websocket
       dry-schema

--- a/lib/multiwoven/integrations/core/base_connector.rb
+++ b/lib/multiwoven/integrations/core/base_connector.rb
@@ -27,10 +27,10 @@ module Multiwoven
       def relative_path
         path = Object.const_source_location(self.class.to_s)[0]
         connector_folder = File.dirname(path)
-        marker = "multiwoven-integrations"
+        marker = "/lib/multiwoven/integrations/"
         parts = connector_folder.split(marker)
 
-        parts.last if parts.length > 1
+        marker + parts.last if parts.length > 1
       end
 
       # Connection config is a hash

--- a/lib/multiwoven/integrations/rollout.rb
+++ b/lib/multiwoven/integrations/rollout.rb
@@ -2,7 +2,7 @@
 
 module Multiwoven
   module Integrations
-    VERSION = "0.1.27"
+    VERSION = "0.1.28"
 
     ENABLED_SOURCES = %w[
       Snowflake


### PR DESCRIPTION
## Description
fix: Avoid numbers in path created by gem in server

## Related Issue
None

## Type of Change
- [ ] New Connector (Destination or Source Connector)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Documentation update
- [ ] Chore
  
## How Has This Been Tested?
Already have written unit test. This issue occurs only when we install the gem which creates a path with gem version number

## Checklist:
- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [x] Added the new connector in rollout.rb
- [x] Have you updated the version number of the gem?
- [ ] Have you ensured that your changes for new connector are documented in the [docs repo](https://github.com/Multiwoven/docs) or relevant documentation files?
- [ ] Have you updated the run time dependency in multiwoven-integrations.gemspec if new gems are added
