### PR TITLE
feat:rate limiting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem "async-websocket", "~> 0.8.0"
 
 gem "git"
 
+gem "ruby-limiter"
+
 group :development, :test do
   gem "simplecov", require: false
   gem "simplecov_json_formatter", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ PATH
       pg
       rake
       restforce
+      ruby-limiter
       ruby-odbc
       sequel
       slack-ruby-client
@@ -208,6 +209,7 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
+    ruby-limiter (2.3.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     sequel (5.75.0)
@@ -264,6 +266,7 @@ DEPENDENCIES
   restforce (~> 7.1.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)
+  ruby-limiter
   ruby-odbc!
   sequel
   simplecov

--- a/lib/multiwoven/integrations.rb
+++ b/lib/multiwoven/integrations.rb
@@ -14,6 +14,7 @@ require "restforce"
 require "logger"
 require "slack-ruby-client"
 require "git"
+require "ruby-limiter"
 
 # Service
 require_relative "integrations/config"
@@ -23,6 +24,7 @@ require_relative "integrations/service"
 # Core
 require_relative "integrations/core/constants"
 require_relative "integrations/core/utils"
+require_relative "integrations/core/rate_limiter"
 require_relative "integrations/protocol/protocol"
 require_relative "integrations/core/base_connector"
 require_relative "integrations/core/source_connector"

--- a/lib/multiwoven/integrations/core/destination_connector.rb
+++ b/lib/multiwoven/integrations/core/destination_connector.rb
@@ -3,7 +3,9 @@
 module Multiwoven
   module Integrations::Core
     class DestinationConnector < BaseConnector
-      # records is transformed json payload send it to the destination
+      prepend RateLimiter
+
+      # Records are transformed json payload send it to the destination
       # SyncConfig is the Protocol::SyncConfig object
       def write(_sync_config, _records, _action = "insert")
         raise "Not implemented"

--- a/lib/multiwoven/integrations/core/rate_limiter.rb
+++ b/lib/multiwoven/integrations/core/rate_limiter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Multiwoven
+  module Integrations::Core
+    module RateLimiter
+      def write(sync_config, records, action = "insert")
+        stream = sync_config.stream
+
+        @queue ||= Limiter::RateQueue.new(stream.request_rate_limit, interval: stream.rate_limit_unit_seconds) do
+          puts "Hit the limit, waiting"
+        end
+
+        @queue.shift
+
+        super(sync_config, records, action)
+      end
+    end
+  end
+end

--- a/lib/multiwoven/integrations/protocol/protocol.rb
+++ b/lib/multiwoven/integrations/protocol/protocol.rb
@@ -23,6 +23,7 @@ module Multiwoven
       "rate_limit", "connection_config"
     )
     LogLevel = Types::String.enum("fatal", "error", "warn", "info", "debug", "trace")
+    RequestRateLimitingUnit = Types::String.default("minute").enum("minute", "hour", "day")
 
     class ProtocolModel < Dry::Struct
       extend Multiwoven::Integrations::Core::Utils
@@ -118,18 +119,18 @@ module Multiwoven
       attribute? :request_method, Types::String.optional
       attribute :batch_support, Types::Bool.default(false)
       attribute :batch_size, Types::Integer.default(1)
-      # rate limits
+      # Rate limits
       attribute? :request_rate_limit, Types::Integer
-      attribute? :request_rate_limit_unit, Types::String
+      attribute? :request_rate_limit_unit, RequestRateLimitingUnit
       attribute? :request_rate_concurrency, Types::Integer
     end
 
     class Catalog < ProtocolModel
       attribute :streams, Types::Array.of(Stream)
 
-      # global rate limit
+      # Rate limits
       attribute? :request_rate_limit, Types::Integer.default(60)
-      attribute? :request_rate_limit_unit, Types::String.default("minute")
+      attribute? :request_rate_limit_unit, RequestRateLimitingUnit
       attribute? :request_rate_concurrency, Types::Integer.default(10)
 
       def to_multiwoven_message

--- a/lib/multiwoven/integrations/protocol/protocol.rb
+++ b/lib/multiwoven/integrations/protocol/protocol.rb
@@ -123,6 +123,19 @@ module Multiwoven
       attribute? :request_rate_limit, Types::Integer
       attribute? :request_rate_limit_unit, RequestRateLimitingUnit
       attribute? :request_rate_concurrency, Types::Integer
+
+      def rate_limit_unit_seconds
+        case request_rate_limit_unit
+        when "minute"
+          60 # Seconds in a minute
+        when "hour"
+          3600 # Seconds in an hour
+        when "day"
+          86_400 # Seconds in a day
+        else
+          1 # Default case, consider as seconds or handle as error
+        end
+      end
     end
 
     class Catalog < ProtocolModel

--- a/lib/multiwoven/integrations/protocol/protocol.rb
+++ b/lib/multiwoven/integrations/protocol/protocol.rb
@@ -118,6 +118,10 @@ module Multiwoven
       attribute? :request_method, Types::String.optional
       attribute :batch_support, Types::Bool.default(false)
       attribute :batch_size, Types::Integer.default(1)
+      # rate limits
+      attribute? :request_rate_limit, Types::Integer
+      attribute? :request_rate_limit_unit, Types::String
+      attribute? :request_rate_concurrency, Types::Integer
     end
 
     class Catalog < ProtocolModel

--- a/lib/multiwoven/integrations/protocol/protocol.rb
+++ b/lib/multiwoven/integrations/protocol/protocol.rb
@@ -123,6 +123,11 @@ module Multiwoven
     class Catalog < ProtocolModel
       attribute :streams, Types::Array.of(Stream)
 
+      # global rate limit
+      attribute? :request_rate_limit, Types::Integer.default(60)
+      attribute? :request_rate_limit_unit, Types::String.default("minute")
+      attribute? :request_rate_concurrency, Types::Integer.default(10)
+
       def to_multiwoven_message
         MultiwovenMessage.new(
           type: MultiwovenMessageType["catalog"],

--- a/multiwoven-integrations.gemspec
+++ b/multiwoven-integrations.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "pg"
   spec.add_runtime_dependency "rake"
   spec.add_runtime_dependency "restforce"
+  spec.add_runtime_dependency "ruby-limiter"
   spec.add_runtime_dependency "ruby-odbc"
   spec.add_runtime_dependency "sequel"
   spec.add_runtime_dependency "slack-ruby-client"

--- a/spec/multiwoven/integrations/core/destination_connector_spec.rb
+++ b/spec/multiwoven/integrations/core/destination_connector_spec.rb
@@ -3,10 +3,17 @@
 module Multiwoven
   module Integrations::Core
     RSpec.describe DestinationConnector do
+      let(:sync_config) { instance_double("SyncConfig", stream: stream) }
+      let(:stream) do
+        instance_double("Stream",
+                        request_rate_limit: 1,
+                        rate_limit_unit_seconds: 60)
+      end
+      let(:records) { %w[record1 record2] }
       describe "#write" do
         it "raises an error for not being implemented" do
           connector = described_class.new
-          expect { connector.write({}, {}) }.to raise_error("Not implemented")
+          expect { connector.write(sync_config, records) }.to raise_error("Not implemented")
         end
       end
     end

--- a/spec/multiwoven/integrations/core/rate_limiter_spec.rb
+++ b/spec/multiwoven/integrations/core/rate_limiter_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.describe Multiwoven::Integrations::Core::RateLimiter do
+  let(:sync_config) { instance_double("SyncConfig", stream: stream) }
+  let(:stream) do
+    instance_double("Stream",
+                    request_rate_limit: 4,
+                    rate_limit_unit_seconds: 1)
+  end
+  let(:records) { %w[record1 record2] }
+
+  let(:limiter_class) do
+    Class.new do
+      prepend Multiwoven::Integrations::Core::RateLimiter
+
+      define_method(:write) do |_sync_config, _records, _action = "insert"|
+        puts "write called"
+      end
+    end.new
+  end
+
+  describe "#write" do
+    it "should set the @queue and call super on calling write" do
+      output = capture_stdout do
+        limiter_class.write(sync_config, records)
+      end
+
+      queue = limiter_class.instance_variable_get(:@queue)
+      expect(queue).not_to be_nil
+      expect(queue).to be_a(Limiter::RateQueue)
+
+      expect(queue.instance_variable_get(:@size)).to eq(stream.request_rate_limit)
+      expect(queue.instance_variable_get(:@interval)).to eq(stream.rate_limit_unit_seconds)
+
+      expect(output).to include("write called")
+    end
+
+    it "should set the @queue once and call super N times on calling write N times" do
+      output = capture_stdout do
+        5.times { limiter_class.write(sync_config, records) }
+      end
+
+      # expect(output.scan(/write called/).length).to eq(4)
+      expect(output).to eq(
+        "write called\nwrite called\nwrite called\nwrite called\nHit the limit, waiting\nwrite called\n"
+      )
+    end
+
+    it "should print logs when ratelimiting hit" do
+      output = capture_stdout do
+        10.times { limiter_class.write(sync_config, records) }
+      end
+      expect(output.scan(/Hit the limit, waiting/).count).to eq(2)
+    end
+  end
+end

--- a/spec/multiwoven/integrations/protocol/protocol_spec.rb
+++ b/spec/multiwoven/integrations/protocol/protocol_spec.rb
@@ -146,7 +146,7 @@ module Multiwoven
           expect(instance.supported_sync_modes).to eq(%w[full_refresh incremental])
 
           expect(instance.request_rate_limit).to be_nil
-          expect(instance.request_rate_limit_unit).to be_nil
+          expect(instance.request_rate_limit_unit).to eq("minute")
           expect(instance.request_rate_concurrency).to be_nil
         end
 

--- a/spec/multiwoven/integrations/protocol/protocol_spec.rb
+++ b/spec/multiwoven/integrations/protocol/protocol_spec.rb
@@ -180,6 +180,7 @@ module Multiwoven
           expect(instance.request_rate_limit).to eq(100)
           expect(instance.request_rate_limit_unit).to eq("minute")
           expect(instance.request_rate_concurrency).to eq(10)
+          expect(instance.rate_limit_unit_seconds).to eq(60)
         end
       end
     end

--- a/spec/multiwoven/integrations/protocol/protocol_spec.rb
+++ b/spec/multiwoven/integrations/protocol/protocol_spec.rb
@@ -144,6 +144,10 @@ module Multiwoven
           expect(instance.batch_support).to eq(false)
           expect(instance.batch_size).to eq(1)
           expect(instance.supported_sync_modes).to eq(%w[full_refresh incremental])
+
+          expect(instance.request_rate_limit).to be_nil
+          expect(instance.request_rate_limit_unit).to be_nil
+          expect(instance.request_rate_concurrency).to be_nil
         end
 
         it "creates an instance from JSON and batch param check" do
@@ -159,7 +163,10 @@ module Multiwoven
             "url": "https://api.example.com/data",
             "request_method": "GET",
             "batch_support": true,
-            "batch_size": 10_000
+            "batch_size": 10_000,
+            "request_rate_limit": 100,
+            "request_rate_limit_unit": "minute",
+            "request_rate_concurrency": 10
           }.to_json
           instance = Stream.from_json(json_data)
           expect(instance).to be_a(Stream)
@@ -169,6 +176,10 @@ module Multiwoven
           expect(instance.batch_support).to eq(true)
           expect(instance.batch_size).to eq(10_000)
           expect(instance.supported_sync_modes).to eq(%w[full_refresh incremental])
+
+          expect(instance.request_rate_limit).to eq(100)
+          expect(instance.request_rate_limit_unit).to eq("minute")
+          expect(instance.request_rate_concurrency).to eq(10)
         end
       end
     end

--- a/spec/multiwoven/integrations/protocol/protocol_spec.rb
+++ b/spec/multiwoven/integrations/protocol/protocol_spec.rb
@@ -176,16 +176,45 @@ module Multiwoven
     RSpec.describe Catalog do
       json_data = {
         "streams" =>
-        [{ "name" => "example_stream",
-           "action" => "create",
-           "json_schema" => { "type" => "object" },
-           "supported_sync_modes" => ["full_refresh"] }]
+        [
+          { "name" => "example_stream",
+            "action" => "create",
+            "json_schema" => { "type" => "object" },
+            "supported_sync_modes" => ["full_refresh"] }
+        ]
       }.to_json
 
       describe ".from_json" do
         it "creates an instance from JSON" do
           instance = Catalog.from_json(json_data)
           expect(instance).to be_a(Catalog)
+          expect(instance.request_rate_limit).to eq(60)
+          expect(instance.request_rate_limit_unit).to eq("minute")
+          expect(instance.request_rate_concurrency).to eq(10)
+          expect(instance.streams.first).to be_a(Stream)
+          expect(instance.streams.first.name).to eq("example_stream")
+        end
+      end
+
+      describe "with ratelimiting configured" do
+        it "creates an instance from JSON" do
+          rate_limited_json_data = {
+            "request_rate_limit" => 100,
+            "request_rate_limit_unit" => "minute",
+            "request_rate_concurrency" => 30,
+            "streams" =>
+            [
+              { "name" => "example_stream",
+                "action" => "create",
+                "json_schema" => { "type" => "object" },
+                "supported_sync_modes" => ["full_refresh"] }
+            ]
+          }.to_json
+          instance = Catalog.from_json(rate_limited_json_data)
+          expect(instance).to be_a(Catalog)
+          expect(instance.request_rate_limit).to eq(100)
+          expect(instance.request_rate_limit_unit).to eq("minute")
+          expect(instance.request_rate_concurrency).to eq(30)
           expect(instance.streams.first).to be_a(Stream)
           expect(instance.streams.first.name).to eq("example_stream")
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,3 +24,12 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
+
+def capture_stdout
+  original_stdout = $stdout
+  $stdout = StringIO.new
+  yield
+  $stdout.string
+ensure
+  $stdout = original_stdout
+end


### PR DESCRIPTION
## Description

# Summary of Rate Limiting Implementation

## Introduction
Rate limiting is crucial for controlling network traffic and preventing overuse of resources. It ensures actions are not repeated too often within a specific timeframe by monitoring requests from each identifier. Exceeding rate limits can lead to costs, violations of terms, and even blacklisting.

## Rate Limits Examples
- **Klaviyo**: 10 requests per second, up to 600 per minute.
- **Salesforce CRM**: 100K requests per day.
- **Facebook Custom Audience**: 600 requests per minute.
- **Hubspot**: 100 requests per 10 seconds.
- **Braze**: 250K requests per hour.

## Use Cases
- Global configuration for all requests in a destination.
- Configurable rate limits for specific API endpoints.
- Configuring concurrent limits for all requests.

## Approach
- **Proactive**: Respecting destination limits to avoid rate limiting errors. This approach requires upfront configuration of rate limits and is complex to implement with dynamic limits.
- **Reactive**: Making API calls without considering limits and waiting after receiving a 429 error. This method adapts to changing rate limits but can lead to redundant API calls.

## Implementation Scope
- The initial implementation will focus on proactive rate limiting with global and concurrency limits. Endpoint-specific limits may be added in future versions.
- Reactive rate limiting is not included in the initial version.

## Solutions
### 1. Simple Rate Limiting
- Utilizes a `Destination` class with a write method for API calls, enforcing rate limits configured in the catalogue.
- Supports batch and individual API calls, with a mechanism to block calls when the rate limit is exceeded.

### 2. Distributed Rate Limiting
- Similar to the first approach but uses Redis as a distributed counter to share the rate limit across syncs, ensuring accurate limiting even with multiple concurrent syncs.

## Trade-offs
- Simple rate limiting is easy to implement and has no dependencies but may not accurately limit rates across multiple syncs.
- Distributed rate limiting provides accuracy in all cases but adds complexity and dependencies.

## Recommendation
- Begin with the simple rate limiting approach and consider moving to distributed rate limiting if concurrent sync issues arise. Ideally, both approaches could be implemented with the first as a fallback.

## Limitations
- Rate limiting configured globally or per stream will not work accurately when two syncs are running concurrently with global rate limits.


## Related Issue
<!-- Link to any related issues or indicate 'None' if applicable e.g
 Relates to issue #123 - 'Improve Salesforce Connector Efficiency'. If none, state 'None'. -->

## Type of Change
- [ ] New Connector (Destination or Source Connector)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Documentation update
- [ ] Chore
  
## How Has This Been Tested?
<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. e.g
Tested with a batch of 10,000 records to ensure data integrity and monitor performance improvements. -->

## Checklist:
- [ ] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [ ] Added the new connector in rollout.rb
- [ ] Have you updated the version number of the gem?
- [ ] Have you ensured that your changes for new connector are documented in the [docs repo](https://github.com/Multiwoven/docs) or relevant documentation files?
- [x] Have you updated the run time dependency in multiwoven-integrations.gemspec if new gems are added
