### PR TITLE
fix: add batch support fields in catalog streams

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    multiwoven-integrations (0.1.49)
+    multiwoven-integrations (0.1.50)
       activesupport
       async-websocket
       csv

--- a/lib/multiwoven/integrations/destination/salesforce_consumer_goods_cloud/schema_helper.rb
+++ b/lib/multiwoven/integrations/destination/salesforce_consumer_goods_cloud/schema_helper.rb
@@ -2,7 +2,7 @@
 
 module Multiwoven
   module Integrations
-    module Source
+    module Destination
       module SalesforceConsumerGoodsCloud
         module SchemaHelper
           include Core::Constants
@@ -100,6 +100,7 @@ module Multiwoven
             json_schema = {
               "$schema": "http://json-schema.org/draft-07/schema#",
               "title": metadata["name"],
+              "batch_support": false,
               "type": "object",
               "additionalProperties": true,
               "properties": fields_schema
@@ -117,7 +118,7 @@ module Multiwoven
               "action": "create",
               "json_schema": json_schema,
               "required": required,
-              "supported_sync_modes": %w[full_refresh incremental],
+              "supported_sync_modes": %w[incremental],
               "source_defined_cursor": true,
               "default_cursor_field": ["updated"],
               "source_defined_primary_key": [primary_key]

--- a/lib/multiwoven/integrations/rollout.rb
+++ b/lib/multiwoven/integrations/rollout.rb
@@ -2,7 +2,7 @@
 
 module Multiwoven
   module Integrations
-    VERSION = "0.1.49"
+    VERSION = "0.1.50"
 
     ENABLED_SOURCES = %w[
       Snowflake

--- a/lib/multiwoven/integrations/source/salesforce_consumer_goods_cloud/schema_helper.rb
+++ b/lib/multiwoven/integrations/source/salesforce_consumer_goods_cloud/schema_helper.rb
@@ -2,7 +2,7 @@
 
 module Multiwoven
   module Integrations
-    module Destination
+    module Source
       module SalesforceConsumerGoodsCloud
         module SchemaHelper
           include Core::Constants
@@ -117,7 +117,7 @@ module Multiwoven
               "action": "create",
               "json_schema": json_schema,
               "required": required,
-              "supported_sync_modes": %w[full_refresh incremental],
+              "supported_sync_modes": %w[incremental],
               "source_defined_cursor": true,
               "default_cursor_field": ["updated"],
               "source_defined_primary_key": [primary_key]

--- a/spec/multiwoven/integrations/destination/salesforce_consumer_goods_cloud/client_spec.rb
+++ b/spec/multiwoven/integrations/destination/salesforce_consumer_goods_cloud/client_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Multiwoven::Integrations::Destination::SalesforceConsumerGoodsClo
         rate_limit_unit_seconds: 1,
         json_schema: salesforce_account_json_schema
       },
-      sync_mode: "full_refresh",
+      sync_mode: "incremental",
       cursor_field: "timestamp",
       destination_sync_mode: "insert" }.with_indifferent_access
   end
@@ -63,6 +63,7 @@ RSpec.describe Multiwoven::Integrations::Destination::SalesforceConsumerGoodsClo
         "$schema" => "http://json-schema.org/draft-07/schema#",
         "title" => "User",
         "type" => "object",
+        "batch_supported" => false,
         "additionalProperties" => true,
         "properties" => {
           "Id" => { "type" => "string" },
@@ -80,6 +81,7 @@ RSpec.describe Multiwoven::Integrations::Destination::SalesforceConsumerGoodsClo
         "$schema" => "http://json-schema.org/draft-07/schema#",
         "title" => "Account",
         "type" => "object",
+        "batch_supported" => false,
         "additionalProperties" => true,
         "properties" => {
           "Id" => { "type" => "string" },

--- a/spec/multiwoven/integrations/destination/salesforce_consumer_goods_cloud/schema_helper_spec.rb
+++ b/spec/multiwoven/integrations/destination/salesforce_consumer_goods_cloud/schema_helper_spec.rb
@@ -43,8 +43,9 @@ RSpec.describe Multiwoven::Integrations::Destination::SalesforceConsumerGoodsClo
       expect(result[:name]).to eq("TestObject")
       expect(result[:action]).to eq("create")
       expect(result[:json_schema]).to be_a(Hash)
+      expect(result[:json_schema][:batch_support]).to eq(false)
       expect(result[:required]).to contain_exactly("Field1")
-      expect(result[:supported_sync_modes]).to contain_exactly("full_refresh", "incremental")
+      expect(result[:supported_sync_modes]).to contain_exactly("incremental")
       expect(result[:source_defined_cursor]).to be true
       expect(result[:default_cursor_field]).to contain_exactly("updated")
     end

--- a/spec/multiwoven/integrations/source/salesforce_consumer_goods/schema_helper_spec.rb
+++ b/spec/multiwoven/integrations/source/salesforce_consumer_goods/schema_helper_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Multiwoven::Integrations::Source::SalesforceConsumerGoodsCloud::S
       expect(result[:action]).to eq("create")
       expect(result[:json_schema]).to be_a(Hash)
       expect(result[:required]).to contain_exactly("Field1")
-      expect(result[:supported_sync_modes]).to contain_exactly("full_refresh", "incremental")
+      expect(result[:supported_sync_modes]).to contain_exactly("incremental")
       expect(result[:source_defined_cursor]).to be true
       expect(result[:default_cursor_field]).to contain_exactly("updated")
     end


### PR DESCRIPTION
## Description
fix: add batch support fields in catalog streams

## Related Issue
None

## Type of Change
- [ ] New Connector (Destination or Source Connector)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Documentation update
- [ ] Chore
  
## How Has This Been Tested?
No

## Checklist:
- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [x] Added the new connector in rollout.rb
- [x] Have you updated the version number of the gem?
- [ ] Have you ensured that your changes for new connector are documented in the [docs repo](https://github.com/Multiwoven/docs) or relevant documentation files?
- [ ] Have you updated the run time dependency in multiwoven-integrations.gemspec if new gems are added
