### PR TITLE
fix: batch size in salesforce Consumer Goods Cloud

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    multiwoven-integrations (0.1.50)
+    multiwoven-integrations (0.1.51)
       activesupport
       async-websocket
       csv

--- a/lib/multiwoven/integrations/destination/salesforce_consumer_goods_cloud/schema_helper.rb
+++ b/lib/multiwoven/integrations/destination/salesforce_consumer_goods_cloud/schema_helper.rb
@@ -100,7 +100,6 @@ module Multiwoven
             json_schema = {
               "$schema": "http://json-schema.org/draft-07/schema#",
               "title": metadata["name"],
-              "batch_support": false,
               "type": "object",
               "additionalProperties": true,
               "properties": fields_schema
@@ -121,7 +120,9 @@ module Multiwoven
               "supported_sync_modes": %w[incremental],
               "source_defined_cursor": true,
               "default_cursor_field": ["updated"],
-              "source_defined_primary_key": [primary_key]
+              "source_defined_primary_key": [primary_key],
+              "batch_support": false,
+              "batch_size": 0
             }
           end
         end

--- a/lib/multiwoven/integrations/rollout.rb
+++ b/lib/multiwoven/integrations/rollout.rb
@@ -2,7 +2,7 @@
 
 module Multiwoven
   module Integrations
-    VERSION = "0.1.50"
+    VERSION = "0.1.51"
 
     ENABLED_SOURCES = %w[
       Snowflake

--- a/spec/multiwoven/integrations/destination/salesforce_consumer_goods_cloud/schema_helper_spec.rb
+++ b/spec/multiwoven/integrations/destination/salesforce_consumer_goods_cloud/schema_helper_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe Multiwoven::Integrations::Destination::SalesforceConsumerGoodsClo
       expect(result[:name]).to eq("TestObject")
       expect(result[:action]).to eq("create")
       expect(result[:json_schema]).to be_a(Hash)
-      expect(result[:json_schema][:batch_support]).to eq(false)
+      expect(result[:batch_support]).to eq(false)
+      expect(result[:batch_size]).to eq(0)
       expect(result[:required]).to contain_exactly("Field1")
       expect(result[:supported_sync_modes]).to contain_exactly("incremental")
       expect(result[:source_defined_cursor]).to be true


### PR DESCRIPTION
## Description
fix: batch size in salesforce cgc

## Related Issue
None

## Type of Change
- [ ] New Connector (Destination or Source Connector)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Documentation update
- [ ] Chore
  
## How Has This Been Tested?
Wrote rspec

## Checklist:
- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [x] Added the new connector in rollout.rb
- [x] Have you updated the version number of the gem?
- [ ] Have you ensured that your changes for new connector are documented in the [docs repo](https://github.com/Multiwoven/docs) or relevant documentation files?
- [ ] Have you updated the run time dependency in multiwoven-integrations.gemspec if new gems are added
